### PR TITLE
Add grid component for simple display of examples

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,27 @@
 import React from 'react';
 import Button from './components/Button';
+import ComponentDisplay from './components/ComponentDisplay';
 import ThemedSection from './components/ThemedSection';
 
 function App() {
   return (
     <div className="App">
-      <section>
-        <p>Here is a button without context or theme</p>
-        <Button>button</Button>
-      </section>
-      <section className="example">
-        <p>Here is a button within context</p>
-        <Button>button with context</Button>
-      </section>
-      <ThemedSection>
+      <ComponentDisplay title="Buttons">
         <div>
-          <p>And finally here is a button within a theme provider</p>
-          <Button>button with theme</Button>
+          <p>Button with &quot;fallback&quot; styling</p>
+          <Button>button</Button>
         </div>
-      </ThemedSection>
+        <div className="example">
+          <p>Here is a button within context</p>
+          <Button>button with context</Button>
+        </div>
+        <ThemedSection>
+          <div>
+            <p>And finally here is a button within a theme provider</p>
+            <Button>button with theme</Button>
+          </div>
+        </ThemedSection>
+      </ComponentDisplay>
     </div>
   );
 }

--- a/src/components/ComponentDisplay.js
+++ b/src/components/ComponentDisplay.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Grid from '../components/Grid';
+import Title from '../components/Title';
+
+function ComponentDisplay(props) {
+  const { children, title } = props;
+  return (
+    <div>
+      {title &&
+        <Title>{title}</Title>
+      }
+      <Grid>{children}</Grid>
+    </div>
+  );
+}
+
+ComponentDisplay.propTypes = {
+  children: PropTypes.node.isRequired,
+  title: PropTypes.string,
+};
+
+ComponentDisplay.defaultProps = {
+  title: null,
+};
+
+export default ComponentDisplay;

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const Grid = styled.div`
+  display: grid;
+  grid-auto-rows: minmax(200px, auto);
+  grid-gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  margin: 0 auto;
+  max-width: 1200px;
+
+  > * {
+    border: 1px dotted #000;
+    padding: 1em;
+  }
+`;
+
+export default Grid;

--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+import Color from '../styles/Color';
+
+const Title = styled.h1`
+  color: ${props => ((props.theme.fg) || Color.accent)};
+  max-width: 1200px;
+  margin: 1em auto;
+`;
+
+export default Title;


### PR DESCRIPTION
Closes #8 

Looking for a quick and easy way to show examples and also get some more use cases covered (wrapper components, etc)
