### PR TITLE
feat(app): Add custom function examples

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { em } from './../styles/Functions';
 
 /*
 here's an example of advanced interpolation using css helper
@@ -14,10 +15,10 @@ const Template = css`
 
 const Button = styled.button`
   ${Template}; /* call our "mixin" */
-  border-radius: 6px;
-  font-size: 1em;
+  border-radius: ${em(6)};
+  font-size: ${em(16)};
   font-weight: bold;
-  padding: 1em 2em;
+  padding: ${em(16)} ${em(32)};
   text-transform: uppercase;
 
   &:focus {

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Button from './Button';
+import { rem } from '../styles/Functions';
 
 /*
   Example of using a CSS variable to reuse props.theme values in multiple
@@ -7,11 +8,11 @@ import Button from './Button';
   component (ButtonGroup).
 */
 const ButtonGroup = styled.div`
-  --border-radius: ${props => props.theme.borderRadius || 0};
+  --border-radius: ${props => rem(props.theme.borderRadius, 14) || 0};
   display: flex;
 
   ${Button} {
-    font-size: .875em; /* TODO: remove once Grid with variable column widths completed  */
+    font-size: ${rem(14)}; /* TODO: remove once Grid with variable column widths completed  */
     border-radius: 0;
 
     &:not(:first-of-type) {

--- a/src/styles/Functions.js
+++ b/src/styles/Functions.js
@@ -1,0 +1,10 @@
+import { isNil, stripUnits } from './Util';
+
+const pxTo = type => (pixelValue, context = 16) => {
+  if (isNil(pixelValue)) return pixelValue;
+
+  return `${stripUnits(pixelValue) / stripUnits(context)}${type}`;
+};
+
+export const em = pxTo('em');
+export const rem = pxTo('rem');

--- a/src/styles/Util.js
+++ b/src/styles/Util.js
@@ -1,0 +1,2 @@
+export const isNil = value => (value === undefined || value === null);
+export const stripUnits = value => (isNil(value) ? value : parseFloat(value));


### PR DESCRIPTION
* px2em, px2rem, stripUnits
* Based off of old Sass functions and the equivalents in Polished (https://github.com/styled-components/polished/blob/master/src/helpers/em.js)

Closes #22 